### PR TITLE
add cuda environment for conda environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,6 +22,8 @@ dependencies:
   - conda-forge::pip
   - conda-forge::openmm=7.5.1
   - conda-forge::pdbfixer
+  - conda-forge::cudatoolkit==11.5.*
+  - conda-forge::cudatoolkit-dev==11.4.*
   - bioconda::hmmer==3.3.2
   - bioconda::hhsuite==3.3.0
   - bioconda::kalign2==2.04


### PR DESCRIPTION
In current environment.yml conda not install cuda related package, that lead pytorch choose cpu version instead cuda version. and will fail when python setup.py install or run the infer.py