### PR TITLE
modify data module for fastfold train

### DIFF
--- a/fastfold/utils/tensor_utils.py
+++ b/fastfold/utils/tensor_utils.py
@@ -1,3 +1,4 @@
+# Copyright 2022 HPC-AI Tech Inc
 # Copyright 2021 AlQuraishi Laboratory
 # Copyright 2021 DeepMind Technologies Limited
 #
@@ -52,7 +53,8 @@ def dict_multimap(fn, dicts):
         if type(v) is dict:
             new_dict[k] = dict_multimap(fn, all_v)
         else:
-            new_dict[k] = fn(all_v)
+            # when bs = 1, returns [...] rather than [1, ...]
+            new_dict[k] = fn(all_v) if len(all_v) > 1 else all_v[0]
 
     return new_dict
 


### PR DESCRIPTION
Because we are not going to build FastFold training on PyTorch-lightning, I refactor the DataSet and DataLoader based on pure PyTorch.

And there are some differences in logic:
The new dataloader only supports batch size(bs) equal to 1, for FastFold was designed without batch dimension. Adding the batch dimension is not hard, but it takes time. Besides, the calculation almost meets the bottleneck of A100 when bs=1, so it would gain very limited speedup by increasing the bs.

For now, when bs=1, the dataloader returns tensor with shape [...] rather than [1, ...](fastfold/utils/tensor_utils.py Line 57).

When bs>1, it would raise an error.