### PR TITLE
[README] remove pre_built wheel of installation and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,19 +53,12 @@ python setup.py install
 
 To leverage the power of FastFold, we recommend you to install [Triton](https://github.com/openai/triton).
 
+**NOTE: Triron needs CUDA 11.4 to run.**
+
 ```bash
-pip install triton==2.0.0.dev20221005
+pip install -U --pre triton
 ```
 
-
-### Using PyPi
-You can download FastFold with pre-built CUDA extensions.
-
-Warning, only stable versions available.
-
-```shell
-pip install fastfold -f https://release.colossalai.org/fastfold
-```
 
 ## Use Docker
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,11 +6,7 @@ RUN conda install openmm=7.7.0 pdbfixer -c conda-forge -y \
 RUN pip install biopython==1.79 dm-tree==0.1.6 ml-collections==0.1.0 \
 scipy==1.7.1 ray pyarrow pandas einops
 
-RUN pip install colossalai==0.1.10+torch1.12cu11.3 -f https://release.colossalai.org
-
-RUN git clone https://github.com/openai/triton.git ~/triton \
- && cd ~/triton/python \
- && pip install -e .
+RUN pip install colossalai
 
 Run git clone https://github.com/hpcaitech/FastFold.git \
  && cd ./FastFold \


### PR DESCRIPTION
1. ColossalAI now removes the downloading page of pre-built wheels. And the PyPI download way is now blocked.
2. triton==2.0.0.dev20221005 is now unavailable. To escape frequently updating, just use the newest.
3. Update Dockerfile.